### PR TITLE
STR63 - Fixed Username not showing in leaderboard

### DIFF
--- a/streatham_go/app/templates/app/leaderboard.html
+++ b/streatham_go/app/templates/app/leaderboard.html
@@ -28,8 +28,9 @@
                 <tr>
                     {% endif %}
                     <td>{{ forloop.counter }}</td>
-                    <td><a href="{% url 'accounts:profile' u.username %}">{{
-                            u.username }}</a></td>
+                    <td><a href="{% url 'accounts:profile' u.username %}">
+                        {{u.username }}
+                    </a></td>
                     <td>{{ u.level }}</td>
                     <td>{{ u.xp }}</td>
                     <td>{{ u.quiz_count }}</td>
@@ -39,9 +40,9 @@
                 {% if current_user_rank > 10 %}
                 <tr class="currentUserRow">
                     <td>{{ current_user_rank }}</td>
-                    <td><a href="{% url 'accounts:profile'
-                            current_user_data.user.username %}">{{
-                            current_user_data.user.username }}</a></td>
+                    <td><a href="{% url 'accounts:profile' current_user_data.user.username %}">
+                        {{ current_user_data.user.username }}
+                    </a></td>
                     <td>{{ current_user_data.level }}</td>
                     <td>{{ current_user_data.xp }}</td>
                     <td>{{ current_user_data.quiz_count }}</td>


### PR DESCRIPTION
Username wasn't showing correctly on the leaderboard, due to the {{ u.username }} and {{ current_user_data.user.username }} lines being split across multiple lines.

Both are now on a single line which fixes this.
