### PR TITLE
Feature/str59

### DIFF
--- a/streatham_go/app/static/app/crossword.css
+++ b/streatham_go/app/static/app/crossword.css
@@ -21,9 +21,6 @@ td {
     font-family: Arial, sans-serif;
     font-size: 18px;
     background-color: rgba(255, 255, 255, 0.7);
-    /* Box shadow should be bigger */
-    /* border-radius: 5px; */
-    backdrop-filter: blur(2px);
     position: relative;
 }
 
@@ -94,9 +91,4 @@ h3 {
 ul {
     list-style-type: none;
     padding: 0;
-}
-
-li {
-    font-size: 16px;
-    margin-bottom: 5px;
 }

--- a/streatham_go/app/static/app/crossword.js
+++ b/streatham_go/app/static/app/crossword.js
@@ -32,6 +32,7 @@ const wordsDict = {
 
 let usableWords = [];
 let placedWords = [];
+let currentOrientation;
 
 // Create a 2d array of size gridSize x gridSize to store the value of each cell
 const gridValues = new Array(gridSize);
@@ -445,25 +446,29 @@ function addCellEventLisenters() {
           e.target.innerText = e.target.innerText.toLowerCase();
 
           // Find the placed word associated with the current cell
-          const placedWord = placedWords.find((word) => {
+
+          // Find all the words associated with the current cell
+          const placedWordsForCell = placedWords.filter((word) => {
             if (word.orientation === 'across') {
               return (
                 e.target.parentNode.rowIndex === word.start.y &&
-                                e.target.cellIndex >= word.start.x &&
-                                e.target.cellIndex < word.start.x + word.word.length
+                e.target.cellIndex >= word.start.x &&
+                e.target.cellIndex < word.start.x + word.word.length
               );
             } else {
               return (
                 e.target.cellIndex === word.start.x &&
-                                e.target.parentNode.rowIndex >= word.start.y &&
-                                e.target.parentNode.rowIndex < word.start.y + word.word.length
+                e.target.parentNode.rowIndex >= word.start.y &&
+                e.target.parentNode.rowIndex < word.start.y + word.word.length
               );
             }
           });
 
+
           // Move focus to the next cell in the word
-          if (placedWord) {
-            const orientation = placedWord.orientation;
+          if (placedWordsForCell.length===1) {
+            console.log(e.target.parentNode.rowIndex, e.target.cellIndex);
+            const orientation = placedWordsForCell[0].orientation;
             if (orientation === 'across') {
               if (e.target.cellIndex + 1 < gridSize) {
                 grid.rows[e.target.parentNode.rowIndex].cells[e.target.cellIndex + 1].focus();
@@ -474,8 +479,57 @@ function addCellEventLisenters() {
               }
             }
           }
+          else{
+            if (placedWordsForCell.length===2){
+              console.log('Two words for cell');
+              let currentCellY = e.target.parentNode.rowIndex;
+              let currentCellX = e.target.cellIndex;
+              let leftEmpty=false;
+              let upEmpty=false;
+              // Check if cell to left is empty
+              if (currentCellX - 1 >= 0 && grid.rows[currentCellY].cells[currentCellX-1].innerText === '') {
+                leftEmpty=true;
+              }
+              // Check if cell above is empty
+              if (currentCellY - 1 >= 0 && grid.rows[currentCellY-1].cells[currentCellX].innerText === '') {
+                upEmpty=true;
+              }
+              // If left is not empty and up is empty, check if right exists
+              if (!leftEmpty && upEmpty){
+                if (currentCellX + 1 < gridSize) {
+                  grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                }
+              } 
+              else if (leftEmpty && !upEmpty){
+                if (currentCellY + 1 < gridSize) {
+                  grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                }
+              }
+              else if (!leftEmpty && !upEmpty){
+                let rightEmpty=false;
+                let downEmpty=false;
+                // Check if cell to right is empty
+                if (currentCellX + 1 < gridSize && grid.rows[currentCellY].cells[currentCellX+1].innerText === '') {
+                  rightEmpty=true;
+                }
+                // Check if cell below is empty
+                if (currentCellY + 1 < gridSize && grid.rows[currentCellY+1].cells[currentCellX].innerText === '') {
+                  downEmpty=true;
+                }
+                // If right is not empty and down is empty, check if left exists
+                if (!rightEmpty && downEmpty){
+                  grid.rows[currentCellY+1].cells[currentCellX].focus();
+                }
+                else if (rightEmpty && !downEmpty){
+                  grid.rows[currentCellY].cells[currentCellX+1].focus();
+                }
+                else if (!rightEmpty && !downEmpty){
+                  //
+                }
+            }
+          }
         }
-
+        }
         // Update hint numbers
         addHintNumbers();
       });

--- a/streatham_go/app/static/app/crossword.js
+++ b/streatham_go/app/static/app/crossword.js
@@ -728,6 +728,8 @@ function checkGrid() {
       if (gridValues[i][j] !== grid.rows[i].cells[j].innerText.slice(0, 1)) {
         // Set the background color of the cell to red
         grid.rows[i].cells[j].style.backgroundColor = 'red';
+        // Set the text value of the cell to the correct answer
+        grid.rows[i].cells[j].innerText = gridValues[i][j];
       } else {
         // Set the background color of the cell to light green
         grid.rows[i].cells[j].style.backgroundColor = '#90ee90';
@@ -770,6 +772,8 @@ function finaliseGrid() {
       grid.rows[i].cells[j].contentEditable = false;
     }
   }
+
+  addHintNumbers();
 
   // Hide the buttons div
   buttonsDiv.style.display = 'none';

--- a/streatham_go/app/static/app/crossword.js
+++ b/streatham_go/app/static/app/crossword.js
@@ -423,6 +423,9 @@ function addHintNumbers() {
 
 /**
  * Adds event listeners to the grid cells to handle user input.
+ * Each cell has two listeners: an input listener and a keydown listener.
+ * The input listener validates user input and moves them to the next cell.
+ * The keydown listener handles the backspace key, and moves them to the previous cell.
  */
 function addCellEventLisenters() {
   // Iterate through the grid cells
@@ -451,8 +454,6 @@ function addCellEventLisenters() {
         // Convert input to lowercase and move focus to the next cell
         if (e.target.innerText !== '') {
           e.target.innerText = e.target.innerText.toLowerCase();
-
-          // Find the placed word associated with the current cell
 
           // Find all the words associated with the current cell
           const placedWordsForCell = placedWords.filter((word) => {
@@ -519,7 +520,8 @@ function addCellEventLisenters() {
                 case 4:
                   // If cell to right exists and it's empty, focus it
                   if (currentCellX + 1 < gridSize &&
-                    grid.rows[currentCellY].cells[currentCellX + 1].innerText === '') {
+                    grid.rows[currentCellY].cells[currentCellX + 1].innerText === '' &&
+                    grid.rows[currentCellY].cells[currentCellX + 1].contentEditable === 'true') {
                     grid.rows[currentCellY].cells[currentCellX + 1].focus();
                   }
                   // Else if down exists, focus it
@@ -602,21 +604,31 @@ function addCellEventLisenters() {
       // Add listener for backspace key
       grid.rows[i].cells[j].addEventListener('keydown', (e) => {
         let currentCell = grid.rows[i].cells[j];
+
+        // Check if the pressed key is 'Backspace'
         if (e.key === 'Backspace') {
+
+          // If the current cell is empty
           if (currentCell.innerText === '') {
-            if (currentCell.cellIndex - 1 >= 0) {
+
+            // If there is a previous cell in the same row and it is editable
+            if (currentCell.cellIndex - 1 >= 0 &&
+              grid.rows[i].cells[i - 1].contentEditable === 'true') {
+              // Focus the previous cell in the same row
               grid.rows[i].cells[j - 1].focus();
             } else {
-              if (currentCell.parentNode.rowIndex - 1 >= 0) {
+              // If there is a row above and the cell in the above row is editable
+              if (currentCell.parentNode.rowIndex - 1 >= 0 &&
+                grid.rows[i - 1].cells[j].contentEditable === 'true') {
+                // Focus the cell in the above row
                 grid.rows[i - 1].cells[j].focus();
               }
             }
           } else {
+            // If the current cell is not empty, clear its content
             currentCell.innerText = '';
           }
         }
-        // Update hint numbers
-        addHintNumbers();
       });
     }
   }

--- a/streatham_go/app/static/app/crossword.js
+++ b/streatham_go/app/static/app/crossword.js
@@ -819,7 +819,6 @@ function calculateScore(userSolved = true) {
 function generateGrid() {
   // Sort the words based on their lengths
   usableWords = sortWords(Object.keys(wordsDict));
-  usableWords = ['sustainable', 'vegetarian', 'reusable', 'organic', 'biofuel', 'vegan'];
 
   // Place the first word in the grid
   placeFirstWord();

--- a/streatham_go/app/static/app/crossword.js
+++ b/streatham_go/app/static/app/crossword.js
@@ -1,4 +1,3 @@
-
 // Get the grid, across and down divs, buttons div, and score div
 const grid = document.getElementById('crossword-grid');
 const acrossDiv = document.getElementById('crossword-hints-across');
@@ -135,8 +134,8 @@ function placeFirstWord() {
   // Store the word, its coordinates, and its orientation in the placedWords array
   placedWords.push({
     word: word,
-    start: {y: middleOfGrid, x: startX},
-    end: {y: middleOfGrid, x: startX + wordLength - 1},
+    start: { y: middleOfGrid, x: startX },
+    end: { y: middleOfGrid, x: startX + wordLength - 1 },
     orientation: 'across',
   });
 
@@ -231,7 +230,7 @@ function checkIfPlaceable(word, intersection) {
         return false;
       }
       if (startX - 1 >= 0 && gridValues[startY + j][startX - 1] !== '' ||
-                startX + 1 < gridSize && gridValues[startY + j][startX + 1] !== '') {
+        startX + 1 < gridSize && gridValues[startY + j][startX + 1] !== '') {
         if (startY + j === intersectionY) {
           continue;
         }
@@ -241,7 +240,7 @@ function checkIfPlaceable(word, intersection) {
 
     // Check for adjacent words
     if ((startY > 0 && gridValues[startY - 1][startX] !== '') ||
-            (startY + wordLength < gridSize && gridValues[startY + wordLength][startX] !== '')) {
+      (startY + wordLength < gridSize && gridValues[startY + wordLength][startX] !== '')) {
       return false;
     }
     return true;
@@ -257,7 +256,7 @@ function checkIfPlaceable(word, intersection) {
         return false;
       }
       if (startY - 1 >= 0 && gridValues[startY - 1][startX + j] !== '' ||
-                (startY + 1 < gridSize && gridValues[startY + 1][startX + j] !== '')) {
+        (startY + 1 < gridSize && gridValues[startY + 1][startX + j] !== '')) {
         if (startX + j === intersectionX) {
           continue;
         }
@@ -267,11 +266,11 @@ function checkIfPlaceable(word, intersection) {
 
     // Check for adjacent words
     if ((startX > 0 && grid.rows[startY].cells[startX - 1].innerText !== '') ||
-            (startX + wordLength < gridSize && grid.rows[startY].cells[startX + wordLength].innerText !== '')) {
+      (startX + wordLength < gridSize && grid.rows[startY].cells[startX + wordLength].innerText !== '')) {
       return false;
     }
     if ((startX > 0 && gridValues[startY][startX - 1] !== '') ||
-            (startX + wordLength < gridSize && gridValues[startY][startX + wordLength] !== '')) {
+      (startX + wordLength < gridSize && gridValues[startY][startX + wordLength] !== '')) {
       return false;
     }
     return true;
@@ -314,8 +313,8 @@ function placeWord(word, intersection) {
   // Store the word and its coordinates in placedWords array
   placedWords.push({
     word: word,
-    start: {y: startY, x: startX},
-    end: orientationToPlace === 'down' ? {y: startY + wordLength - 1, x: startX} : {y: startY, x: startX + wordLength - 1},
+    start: { y: startY, x: startX },
+    end: orientationToPlace === 'down' ? { y: startY + wordLength - 1, x: startX } : { y: startY, x: startX + wordLength - 1 },
     orientation: orientationToPlace,
   });
 
@@ -378,6 +377,13 @@ function formatGrid() {
   }
 }
 
+function removeHintNumbers() {
+  // If any cell has a number, remove it
+  const hintNumbers = document.querySelectorAll('.hint-number');
+  for (let i = 0; i < hintNumbers.length; i++) {
+    hintNumbers[i].remove();
+  }
+}
 /**
  * Adds hint numbers to the first letter of each word on the grid.
  */
@@ -409,6 +415,7 @@ function addHintNumbers() {
     } else {
       spanElement.innerText += ', ' + hintNumber;
     }
+    // Disable clicking on the hintElement
 
     hintNumber++;
   }
@@ -464,10 +471,8 @@ function addCellEventLisenters() {
             }
           });
 
-
           // Move focus to the next cell in the word
-          if (placedWordsForCell.length===1) {
-            console.log(e.target.parentNode.rowIndex, e.target.cellIndex);
+          if (placedWordsForCell.length === 1) {
             const orientation = placedWordsForCell[0].orientation;
             if (orientation === 'across') {
               if (e.target.cellIndex + 1 < gridSize) {
@@ -478,57 +483,137 @@ function addCellEventLisenters() {
                 grid.rows[e.target.parentNode.rowIndex + 1].cells[e.target.cellIndex].focus();
               }
             }
-          }
-          else{
-            if (placedWordsForCell.length===2){
-              console.log('Two words for cell');
+          } else {
+            if (placedWordsForCell.length === 2) {
+              removeHintNumbers();
               let currentCellY = e.target.parentNode.rowIndex;
               let currentCellX = e.target.cellIndex;
-              let leftEmpty=false;
-              let upEmpty=false;
+              // If empty, 0
+              // If cell doesn't exist, 1
+              // If full, 2
+              let leftEmpty = 2;
+              let upEmpty = 2;
               // Check if cell to left is empty
-              if (currentCellX - 1 >= 0 && grid.rows[currentCellY].cells[currentCellX-1].innerText === '') {
-                leftEmpty=true;
-              }
+              if (currentCellX - 1 >= 0 &&
+                grid.rows[currentCellY].cells[currentCellX - 1].innerText === '') {
+                if (grid.rows[currentCellY].cells[currentCellX - 1].contentEditable === 'true') {
+                  leftEmpty = 0;
+                } else {
+                  leftEmpty = 1;
+                }
+              };
               // Check if cell above is empty
-              if (currentCellY - 1 >= 0 && grid.rows[currentCellY-1].cells[currentCellX].innerText === '') {
-                upEmpty=true;
-              }
-              // If left is not empty and up is empty, check if right exists
-              if (!leftEmpty && upEmpty){
-                if (currentCellX + 1 < gridSize) {
-                  grid.rows[currentCellY].cells[currentCellX + 1].focus();
-                }
-              } 
-              else if (leftEmpty && !upEmpty){
-                if (currentCellY + 1 < gridSize) {
-                  grid.rows[currentCellY + 1].cells[currentCellX].focus();
+              if (currentCellY - 1 >= 0 &&
+                grid.rows[currentCellY - 1].cells[currentCellX].innerText === '') {
+                if (grid.rows[currentCellY - 1].cells[currentCellX].contentEditable === 'true') {
+                  upEmpty = 0;
+                } else {
+                  upEmpty = 1;
                 }
               }
-              else if (!leftEmpty && !upEmpty){
-                let rightEmpty=false;
-                let downEmpty=false;
-                // Check if cell to right is empty
-                if (currentCellX + 1 < gridSize && grid.rows[currentCellY].cells[currentCellX+1].innerText === '') {
-                  rightEmpty=true;
-                }
-                // Check if cell below is empty
-                if (currentCellY + 1 < gridSize && grid.rows[currentCellY+1].cells[currentCellX].innerText === '') {
-                  downEmpty=true;
-                }
-                // If right is not empty and down is empty, check if left exists
-                if (!rightEmpty && downEmpty){
-                  grid.rows[currentCellY+1].cells[currentCellX].focus();
-                }
-                else if (rightEmpty && !downEmpty){
-                  grid.rows[currentCellY].cells[currentCellX+1].focus();
-                }
-                else if (!rightEmpty && !downEmpty){
-                  //
-                }
+
+              let sum = leftEmpty + upEmpty;
+
+              switch (sum) {
+                case 0:
+                case 4:
+                  // If cell to right exists and it's empty, focus it
+                  if (currentCellX + 1 < gridSize &&
+                    grid.rows[currentCellY].cells[currentCellX + 1].innerText === '') {
+                    grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                  }
+                  // Else if down exists, focus it
+                  else if (currentCellY + 1 < gridSize) {
+                    grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                  }
+                  break;
+                case 1:
+                  if (leftEmpty === 0) {
+                    // Go down
+                    if (currentCellY + 1 < gridSize) {
+                      grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                    }
+                  } else {
+                    // Go right
+                    if (currentCellX + 1 < gridSize) {
+                      grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                    }
+                  }
+                  break;
+                case 2:
+                  if (leftEmpty === 1 && upEmpty === 1) {
+                    // If empty, go right
+                    if (currentCellX + 1 < gridSize &&
+                      grid.rows[currentCellY].cells[currentCellX + 1].innerText === '') {
+                      grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                    } else {
+                      // If empty, go down
+                      if (currentCellY + 1 < gridSize &&
+                        grid.rows[currentCellY + 1].cells[currentCellX].innerText === '') {
+                        grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                      }
+                    }
+                  } else {
+                    if (leftEmpty === 0) {
+                      // Go down
+                      if (currentCellY + 1 < gridSize) {
+                        grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                      }
+                    } else {
+                      // Go right
+                      if (currentCellX + 1 < gridSize) {
+                        grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                      }
+                    }
+                  }
+                  break;
+                case 3:
+                  if (leftEmpty === 1) {
+                    // If empty, do down
+                    if (currentCellY + 1 < gridSize &&
+                      grid.rows[currentCellY + 1].cells[currentCellX].innerText === '') {
+                      grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                    } else {
+                      // Go right
+                      if (currentCellX + 1 < gridSize) {
+                        grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                      }
+                    }
+                  } else if (upEmpty === 1) {
+                    // If empty, go right
+                    if (currentCellX + 1 < gridSize &&
+                      grid.rows[currentCellY].cells[currentCellX + 1].innerText === '') {
+                      grid.rows[currentCellY].cells[currentCellX + 1].focus();
+                    } else {
+                      // Go down
+                      if (currentCellY + 1 < gridSize) {
+                        grid.rows[currentCellY + 1].cells[currentCellX].focus();
+                      }
+                    }
+                  }
+                  break;
+              }
             }
           }
         }
+        // Update hint numbers
+        addHintNumbers();
+      });
+      // Add listener for backspace key
+      grid.rows[i].cells[j].addEventListener('keydown', (e) => {
+        let currentCell = grid.rows[i].cells[j];
+        if (e.key === 'Backspace') {
+          if (currentCell.innerText === '') {
+            if (currentCell.cellIndex - 1 >= 0) {
+              grid.rows[i].cells[j - 1].focus();
+            } else {
+              if (currentCell.parentNode.rowIndex - 1 >= 0) {
+                grid.rows[i - 1].cells[j].focus();
+              }
+            }
+          } else {
+            currentCell.innerText = '';
+          }
         }
         // Update hint numbers
         addHintNumbers();
@@ -734,6 +819,7 @@ function calculateScore(userSolved = true) {
 function generateGrid() {
   // Sort the words based on their lengths
   usableWords = sortWords(Object.keys(wordsDict));
+  usableWords = ['sustainable', 'vegetarian', 'reusable', 'organic', 'biofuel', 'vegan'];
 
   // Place the first word in the grid
   placeFirstWord();


### PR DESCRIPTION
## Crossword Game 

Since last PR, fixed cell focus changing when reaching an intersection of two words.

### Cell Change Logic
![image](https://user-images.githubusercontent.com/73535967/226192043-a3b2d6b5-e48b-4d49-aff8-8a93b9f5ea31.png)

As the image shows, there are nine different "states" an intersection between words can be in. If trying to insert a letter into cell[Y][X] where Y is the row and X is the column, the cell to the left (cell[Y][X-1]) and the cell above (cell[Y-1][X]), can each be in three different states:
- empty
- doesn't exist
- full.
Empty is when a grid square that can take a letter is empty, doesn't exist is when trying to access a cell that, although may be valid coordinates within the grid, it does not form a word so is not a clickable cell, and full meaning a letter is in the cell.
Depending on which state an intersection is in will depend on which cell to move to after. Essentially, it moves the focus to the next logical cell that a user would want to type in.


### Cell Deletion
Pressing backspace will now clear the cell of any contents, even if backspacing behind the character.
If the cell is already empty, the focus will shift to the previous cell, either going up or going left. However this is not perfect and when an intersection is reached, going left will always be prioritised even if going upwards, but every other scenario should work.
